### PR TITLE
 Add support for releasing as a Debian package

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,19 +29,9 @@ https://vuejs.org/v2/style-guide/#ad
 * Ensure all changes have been merged and are pulled into the local copy.
 * Update the version number and tag the new version with: `npm version <new-version>`
 * Push the tag to Github: `git push origin <version>`
+* Build the distribution: `npm run build`
 * Build the deb package: `nfpm pkg -t cacophony-web-vuex_<version>.deb`
 * Upload the resulting package to the [Github Releases](https://github.com/TheCacophonyProject/cacophony-web-vuex/releases) for cacophony-web-vuex
 
-The index.html file in the root of the distribution should be served
-via a web server. An express example might look as follows:
-
-```javascript
-const express = require('express');
-const app = express();
-const path = require('path');
-
-app.use('/dist', express.static(path.join(__dirname, '../cacophony-web-vuex/dist')));
-app.use('/*', express.static(path.join(__dirname, '/')));
-
-app.listen(3000, () => console.log('Listening on port 3000!'));
-```
+The /srv/cacophony/cacophony-web-vuex directory in the package should
+be served by a web server.

--- a/README.md
+++ b/README.md
@@ -24,14 +24,16 @@ For detailed explanation on how things work, consult the [docs for vue-loader](h
 Please follow the Vue style guide for all development:
 https://vuejs.org/v2/style-guide/#ad
 
-# Production
+# Production Releases
 
-Create the distribution file
-``` bash
-npm run build
-```
+* Ensure all changes have been merged and are pulled into the local copy.
+* Update the version number and tag the new version with: `npm version <new-version>`
+* Push the tag to Github: `git push origin <version>`
+* Build the deb package: `nfpm pkg -t cacophony-web-vuex_<version>.deb`
+* Upload the resulting package to the [Github Releases](https://github.com/TheCacophonyProject/cacophony-web-vuex/releases) for cacophony-web-vuex
 
-The index.html file in the root of the project should be served via a web server, an express example might look as follows:
+The index.html file in the root of the distribution should be served
+via a web server. An express example might look as follows:
 
 ```javascript
 const express = require('express');

--- a/configs/app.config.prod.js
+++ b/configs/app.config.prod.js
@@ -1,3 +1,3 @@
 module.exports = {
-  'api': "http://localhost:2000"
+  'api': "https://api-test.cacophony.org.nz"
 };

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -9,5 +9,5 @@ vendor: "The Cacophony Project"
 homepage: https://github.com/TheCacophonyProject
 license: "GPLv3"
 files:
-  ./index.html: "/srv/cacophony/cacophony-web-vuex/"
+  ./index.html: "/srv/cacophony/cacophony-web-vuex/index.html"
   ./dist/*: "/srv/cacophony/cacophony-web-vuex/dist/"

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,7 +1,7 @@
 name: "cacophony-web-vuex"
 arch: "amd64"
 platform: "linux"
-version: "0.0.2"
+version: "0.0.3"
 maintainer: "Cacophony Developers <dev@cacophony.org.nz>"
 description: |
   Web interface for the Cacophony Project API

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,7 +1,7 @@
 name: "cacophony-web-vuex"
 arch: "amd64"
 platform: "linux"
-version: "0.0.1"
+version: "0.0.2"
 maintainer: "Cacophony Developers <dev@cacophony.org.nz>"
 description: |
   Web interface for the Cacophony Project API

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,7 +1,7 @@
 name: "cacophony-web-vuex"
 arch: "amd64"
 platform: "linux"
-version: "0.0.0"
+version: "0.0.1"
 maintainer: "Cacophony Developers <dev@cacophony.org.nz>"
 description: |
   Web interface for the Cacophony Project API

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,0 +1,13 @@
+name: "cacophony-web-vuex"
+arch: "amd64"
+platform: "linux"
+version: "0.0.0"
+maintainer: "Cacophony Developers <dev@cacophony.org.nz>"
+description: |
+  Web interface for the Cacophony Project API
+vendor: "The Cacophony Project"
+homepage: https://github.com/TheCacophonyProject
+license: "GPLv3"
+files:
+  ./index.html: "/srv/cacophony/cacophony-web-vuex/"
+  ./dist/*: "/srv/cacophony/cacophony-web-vuex/dist/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cacophony-web-vue",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cacophony-web-vue",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cacophony-web-vue",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "test": "cross-env NODE_ENV=test jest",
     "test:watch": "cross-env NODE_ENV=test npm run test -- --watch",
     "lint": "eslint ./src --ext .js,.vue",
-    "lint-fix": "eslint ./src --fix --ext .js,.vue"
+    "lint-fix": "eslint ./src --fix --ext .js,.vue",
+    "preversion": "npm test",
+    "version": "./update-nfpm-version"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cacophony-web-vue",
   "description": "Cacophony web",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": "Andy Saunders <adbs1@yahoo.com>",
   "license": "MIT",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cacophony-web-vue",
   "description": "Cacophony web",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "author": "Andy Saunders <adbs1@yahoo.com>",
   "license": "MIT",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cacophony-web-vue",
   "description": "Cacophony web",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": "Andy Saunders <adbs1@yahoo.com>",
   "license": "MIT",
   "private": true,

--- a/update-nfpm-version
+++ b/update-nfpm-version
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# This script writes the version number in $npm_package_version into
+# the correct place in nfpm.yaml. It is called by a script target in
+# packages.json.
+
+perl -pi -e "s/^version:.+/version: \"$npm_package_version\"/" nfpm.yaml
+git add nfpm.yaml


### PR DESCRIPTION
This adds support for building the application and distributing it as a Debian package. Eventually this will be done as part of our CI pipeline but for now there's some (documented) semi-automatic steps to follow.

Packages end up on Github under the Releases section.

Outstanding issue: the output from webpack includes a hardcoded API URL which means the package only works for the prod or test environment. This needs to be resolved.