### PR TITLE
Improve support for audio recordings

### DIFF
--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,7 +1,7 @@
 name: "cacophony-web-vuex"
 arch: "amd64"
 platform: "linux"
-version: "0.0.3"
+version: "0.1.0"
 maintainer: "Cacophony Developers <dev@cacophony.org.nz>"
 description: |
   Web interface for the Cacophony Project API

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cacophony-web-vue",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cacophony-web-vue",
   "description": "Cacophony web",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "author": "Andy Saunders <adbs1@yahoo.com>",
   "license": "MIT",
   "private": true,

--- a/src/components/QueryRecordings/QueryRecordings.vue
+++ b/src/components/QueryRecordings/QueryRecordings.vue
@@ -82,7 +82,6 @@ export default {
   methods: {
     buildQuery() {
       const query = {
-        type: 'thermalRaw',
         where: {}
       };
       // Add devices

--- a/src/components/TableRecordings.vue
+++ b/src/components/TableRecordings.vue
@@ -7,13 +7,30 @@
     responsive
     class="recording-table">
     <template
-      slot="view"
+      slot="id"
       slot-scope="row">
-      <b-button
-        :to="'/video/' + row.item.id"
+      <a
+        :href="'/video/' + row.item.id"
         target="_blank">
-        View
-      </b-button>
+        {{ row.item.id }}
+      </a>
+    </template>
+    <template
+      slot="type"
+      slot-scope="{item: { type }}">
+      <template v-if="type === 'audio'">
+        <span title="Audio">
+          <font-awesome-icon icon="music"/>
+        </span>
+      </template>
+      <template v-else-if="type === 'thermalRaw'">
+        <span title="Thermal video">
+          <font-awesome-icon icon="video"/>
+        </span>
+      </template>
+      <template v-else>
+        {{ type }}
+      </template>
     </template>
     <template
       slot="other"
@@ -39,11 +56,11 @@ export default {
     return {
       fields: [
         {
-          key: 'view',
-          label: 'View'
+          key: 'id',
+          label: 'ID'
         },
         {
-          key: 'id'
+          key: 'type'
         },
         {
           key: 'devicename',

--- a/src/components/TableRecordings.vue
+++ b/src/components/TableRecordings.vue
@@ -57,10 +57,10 @@ export default {
           key: 'location'
         },
         {
-          key: 'time'
+          key: 'date'
         },
         {
-          key: 'date'
+          key: 'time'
         },
         {
           key: 'duration'

--- a/src/components/TableRecordings.vue
+++ b/src/components/TableRecordings.vue
@@ -10,7 +10,7 @@
       slot="id"
       slot-scope="row">
       <a
-        :href="'/video/' + row.item.id"
+        :href="'/recording/' + row.item.id"
         target="_blank">
         {{ row.item.id }}
       </a>

--- a/src/components/Video/PrevNext.vue
+++ b/src/components/Video/PrevNext.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="img-buttons">
     <img
       class="img-button"
       title="Previous for device, skipping bird &amp; false-positives"
@@ -60,13 +60,14 @@ export default {
 </script>
 
 <style scoped>
+.img-buttons {
+  padding: 1em;
+  text-align: center;
+}
 .img-button {
   cursor: pointer;
   box-sizing: border-box;
-  max-width: 15%;
-  max-height: 75px;
-  width: auto;
-  height: auto;
+  width: 4em;
+  max-height: 4em;
 }
-
 </style>

--- a/src/components/Video/QuickTag.vue
+++ b/src/components/Video/QuickTag.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="tag-buttons">
     <img
       class="tag-button"
       title="Mark as possum"
@@ -74,11 +74,14 @@ export default {
 </script>
 
 <style scoped>
+.tag-buttons {
+  padding: 1em;
+  text-align: center;
+}
 .tag-button {
-  max-width: 15%;
-  max-height: 75px;
-  width: auto;
-  height: auto;
+  box-sizing: border-box;
+  width: 3.5em;
+  max-height: 3.5em;
   cursor: pointer;
 }
 </style>

--- a/src/components/Video/VideoProperties.vue
+++ b/src/components/Video/VideoProperties.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <h3>Video properties</h3>
     <b-form>
       <b-form-group
         label="Processing:"
@@ -21,7 +20,7 @@
           <div class="col-md-1" />
           <b-button
             class="col-md-3"
-            @click="updateComment">Save Comment</b-button>
+            @click="updateComment">Save</b-button>
         </b-form-row>
       </b-form-group>
       <b-alert
@@ -34,7 +33,7 @@
         <b-button
           :block="true"
           variant="danger"
-          @click="deleteRecording()">Delete Video</b-button>
+          @click="deleteRecording()">Delete</b-button>
       </b-form-group>
       <b-alert
         :show="showDeleteAlert"
@@ -44,7 +43,6 @@
 
     </b-form>
 
-    <h3>Download Files</h3>
     <b-button
       :href="downloadRawUrl"
       target="_blank">Download Raw</b-button>

--- a/src/fontAwesomeIcons.js
+++ b/src/fontAwesomeIcons.js
@@ -1,6 +1,12 @@
 import {library} from '@fortawesome/fontawesome-svg-core';
 import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
-import {faBatteryThreeQuarters, faCog, faTrash} from '@fortawesome/free-solid-svg-icons';
+import {
+  faBatteryThreeQuarters,
+  faCog,
+  faTrash,
+  faVideo,
+  faMusic
+} from '@fortawesome/free-solid-svg-icons';
 import {
   faCaretSquareDown,
   faCaretSquareLeft,
@@ -18,7 +24,9 @@ library.add(
   faCaretSquareLeft,
   faWindowClose,
   faCog,
-  faBatteryThreeQuarters
+  faBatteryThreeQuarters,
+  faVideo,
+  faMusic
 );
 
 export default FontAwesomeIcon;

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -12,7 +12,7 @@ import HomeView from '../views/HomeView.vue';
 import LoginView from '../views/LoginView.vue';
 import RecordingsView from '../views/RecordingsView.vue';
 import RegisterView from '../views/RegisterView.vue';
-import VideoView from '../views/VideoView.vue';
+import RecordingVue from '../views/RecordingView.vue';
 import AddEmailView from '../views/AddEmailView.vue';
 
 Vue.use(Router);
@@ -33,7 +33,7 @@ function createRouter() {
       {path:'/login', name: 'login', component:LoginView, meta: {noAuth: true}},
       {path:'/recordings',component:RecordingsView},
       {path:'/register',component:RegisterView, meta: {noAuth: true}},
-      {path:'/video/:id',component:VideoView},
+      {path:'/recording/:id', component: RecordingVue},
       {path:'/add_email', name: 'addEmail', component: AddEmailView, meta: {noEmail: true}},
     ]
   });

--- a/src/views/RecordingView.vue
+++ b/src/views/RecordingView.vue
@@ -8,30 +8,37 @@
       <b-col
         cols="12"
         lg="8">
-        <video
-          ref="videoPlayer"
-          :key="recording.id"
-          controls
-          autoplay
-          max-width="100%"
-          width="640"
-          height="auto"
-          class="video">
-          <source :src="fileSource" >
-          Sorry, your browser does not support video playback.
-        </video>
-        <QuickTag
-          v-show="!showAddObservation"
-          @addTag="addTag($event)"
-          @displayAddObservation="showAddObservation = true"/>
-        <AddObservation
-          v-show="showAddObservation"
-          :current-video-time="currentVideoTime"
-          @get-current-video-time="getCurrentVideoTime()"
-          @set-current-video-time="setCurrentVideoTime($event)"
-          @addTag="addTag($event)"
-          @hideAddObservations="showAddObservation = false"
-        />
+        <template v-if="isVideo">
+          <video
+            ref="player"
+            :key="recording.id"
+            controls
+            autoplay
+            height="auto"
+            class="video">
+            <source :src="fileSource" >
+            Sorry, your browser does not support video playback.
+          </video>
+          <QuickTag
+            v-show="!showAddObservation"
+            @addTag="addTag($event)"
+            @displayAddObservation="showAddObservation = true"/>
+          <AddObservation
+            v-show="showAddObservation"
+            :current-video-time="currentVideoTime"
+            @get-current-video-time="getCurrentVideoTime()"
+            @set-current-video-time="setCurrentVideoTime($event)"
+            @addTag="addTag($event)"
+            @hideAddObservations="showAddObservation = false" />
+        </template>
+        <template v-else>
+          <audio
+            ref="player"
+            :src="fileSource"
+            controls
+            autoplay
+            class="audio"/>
+        </template>
         <PrevNext
           :recording="recording"
           @nextRecording="nextRecording($event.direction, $event.tagMode, $event.tags)"/>
@@ -41,6 +48,7 @@
           dismissible
           @dismissed="showAlert=false">{{ alertMessage }}</b-alert>
         <ObservedAnimals
+          v-if="isVideo"
           :items="tagItems"
           @deleteTag="deleteTag($event)"/>
       </b-col>
@@ -90,6 +98,7 @@ export default {
       recording: state => state.Video.recording,
       downloadFileJWT: state => state.Video.downloadFileJWT,
       downloadRawJWT: state => state.Video.downloadRawJWT,
+      isVideo: state => state.Video.recording.type == "thermalRaw",
       date: (state) => {
         const date = new Date(state.Video.recording.recordingDateTime);
         return date.toLocaleDateString('en-NZ');
@@ -161,13 +170,13 @@ export default {
       };
 
       await this.$store.dispatch('Video/QUERY_RECORDING', { params, direction });
-      this.$router.push({path: `/video/${this.recording.id}`});
+      this.$router.push({path: `/recording/${this.recording.id}`});
     },
     getCurrentVideoTime() {
-      this.currentVideoTime = this.$refs.videoPlayer.currentTime;
+      this.currentVideoTime = this.$refs.player.currentTime;
     },
     setCurrentVideoTime(time) {
-      this.$refs.videoPlayer.currentTime = time;
+      this.$refs.player.currentTime = time;
     }
   }
 };
@@ -176,8 +185,15 @@ export default {
 <style>
 
 .video {
+  min-width: 100%;
   max-width: 100%;
   height: auto;
+}
+
+.audio {
+  display: block;
+  min-width: 100%;
+  max-width: 100%;
 }
 
 </style>

--- a/src/views/RecordingView.vue
+++ b/src/views/RecordingView.vue
@@ -73,7 +73,7 @@ import VideoProperties from '../components/Video/VideoProperties.vue';
 import VideoHelp from '../components/Video/VideoHelp.vue';
 
 export default {
-  name: 'VideoView',
+  name: 'RecordingView',
   components: {QuickTag, PrevNext, AddObservation, ObservedAnimals, VideoProperties, VideoHelp},
   props: {},
   data () {

--- a/src/views/RecordingsView.vue
+++ b/src/views/RecordingsView.vue
@@ -75,12 +75,13 @@ export default {
       count: null,
       countMessage: null,
       currentPage: null,
-      perPage: 100,
+      perPage: 300,
       limitPaginationButtons: 5,
       perPageOptions: [
         {value: 10, text: "10 per page"},
         {value: 50, text: "50 per page"},
         {value: 100, text: "100 per page"},
+        {value: 300, text: "300 per page"},
         {value: 500, text: "500 per page"},
         {value: 1000, text: "1000 per page"}
       ]

--- a/src/views/RecordingsView.vue
+++ b/src/views/RecordingsView.vue
@@ -1,7 +1,6 @@
 <template>
   <div>
     <b-container>
-      <h1>Search Video Recordings</h1>
       <QueryRecordings
         v-model="query"
         @searchButton="searchButton"/>
@@ -132,6 +131,7 @@ export default {
         response.rows.map((row) => {
           this.tableItems.push({
             id: row.id,
+            type: row.type,
             devicename: row.Device.devicename,
             groupname: row.Group.groupname,
             location: this.parseLocation(row.location),

--- a/src/views/VideoView.vue
+++ b/src/views/VideoView.vue
@@ -2,7 +2,6 @@
   <b-container v-if="recording">
     <b-row>
       <b-col cols="12">
-        <h1>View Recording</h1>
         <h4>'{{ recording.Device.devicename }}' - {{ date }}, {{ time }}</h4>
       </b-col>
 


### PR DESCRIPTION
- swap date and time columns on recordings query results table
- default to 300 recordings per page (requested by Grant)
- Show recording type as icon
- Remove unnecessary text from recording view
- Rename VideoView to RecordingView and adjust routes
- Use <audio> for playing audio
- Make video player take up full width
- Fix size and alignment of prev/next & tag buttons

Fixes #32. Also deals with much of #18.