### PR TITLE
Disable tag types and animal input when recording type includes audio

### DIFF
--- a/src/components/QueryRecordings/QueryRecordings.vue
+++ b/src/components/QueryRecordings/QueryRecordings.vue
@@ -16,13 +16,15 @@
       sm="6"
       md="2">
       <SelectTagTypes
-        v-model="tagTypes"/>
+        v-model="tagTypes"
+        :disabled="isAudio"/>
     </b-col>
     <b-col
       sm="6"
       md="4">
       <SelectAnimal
-        v-model="animals"/>
+        v-model="animals"
+        :disabled="isAudio"/>
     </b-col>
     <b-col
       sm="6"
@@ -86,6 +88,27 @@ export default {
       tagTypes: 'any',
       recordingType: 'both'
     };
+  },
+  computed: {
+    isAudio: function () {
+      // If it is an audio recording, then animals and tag types should be
+      // disabled as these filters do not apply to audio recordings
+      if (this.recordingType === 'video') {
+        return false;
+      } else {
+        return true;
+      }
+    }
+  },
+  watch: {
+    'isAudio': function () {
+      if (this.isAudio) {
+        // Reset any existing filters for animals and tag types when searching
+        // for audio recordings
+        this.animals = [];
+        this.tagTypes = 'any';
+      }
+    }
   },
   methods: {
     buildQuery() {

--- a/src/components/QueryRecordings/QueryRecordings.vue
+++ b/src/components/QueryRecordings/QueryRecordings.vue
@@ -85,8 +85,7 @@ export default {
       animals: [],
       fromDate: "",
       toDate: "",
-      tagTypes: 'any',
-      recordingType: 'both'
+      tagTypes: 'any'
     };
   },
   computed: {
@@ -97,6 +96,14 @@ export default {
         return false;
       } else {
         return true;
+      }
+    },
+    recordingType: {
+      get () {
+        return this.$store.state.User.recordingTypePref;
+      },
+      set (value) {
+        this.$store.commit('User/updateRecordingTypePref', value);
       }
     }
   },

--- a/src/components/QueryRecordings/QueryRecordings.vue
+++ b/src/components/QueryRecordings/QueryRecordings.vue
@@ -92,11 +92,7 @@ export default {
     isAudio: function () {
       // If it is an audio recording, then animals and tag types should be
       // disabled as these filters do not apply to audio recordings
-      if (this.recordingType === 'video') {
-        return false;
-      } else {
-        return true;
-      }
+      return this.recordingType !== "video";
     },
     recordingType: {
       get () {
@@ -108,7 +104,7 @@ export default {
     }
   },
   watch: {
-    'isAudio': function () {
+    isAudio: function () {
       if (this.isAudio) {
         // Reset any existing filters for animals and tag types when searching
         // for audio recordings

--- a/src/components/QueryRecordings/SelectAnimal.vue
+++ b/src/components/QueryRecordings/SelectAnimal.vue
@@ -1,11 +1,13 @@
 <template>
-  <b-form-group>
+  <b-form-group
+    v-b-tooltip.hover="tooltipTitle">
     <label>Animals</label>
     <multiselect
       :value="value"
       :options="options"
       :multiple="true"
       :placeholder="placeholder"
+      :disabled="disabled"
       @input="$emit('input', $event)"/>
   </b-form-group>
 </template>
@@ -18,11 +20,14 @@ export default {
     value: {
       type: Array,
       required: true
+    },
+    disabled: {
+      type: Boolean,
+      default: false
     }
   },
   data () {
     return {
-      thisvalue: ["interesting", "possum"],
       options: [
         "interesting",
         "possum",
@@ -53,6 +58,13 @@ export default {
         return "add more animals";
       } else {
         return "all animals";
+      }
+    },
+    tooltipTitle: function () {
+      if (this.disabled) {
+        return 'Disabled when recording type includes audio';
+      } else {
+        return "";
       }
     }
   },

--- a/src/components/QueryRecordings/SelectTagTypes.vue
+++ b/src/components/QueryRecordings/SelectTagTypes.vue
@@ -1,10 +1,12 @@
 <template>
-  <b-form-group>
+  <b-form-group
+    v-b-tooltip.hover="tooltipTitle">
     <label>Tag Types</label>
 
     <b-form-select
       :value="value"
       :options="options"
+      :disabled="disabled"
       placeholder="any"
       @input="$emit('input', $event)"
     />
@@ -18,6 +20,10 @@ export default {
     value: {
       type: String,
       required: true
+    },
+    disabled: {
+      type: Boolean,
+      default: false
     }
   },
   data () {
@@ -31,6 +37,15 @@ export default {
         { value: 'automatic+human', text: 'both automatic & manual'}
       ]
     };
+  },
+  computed: {
+    tooltipTitle: function () {
+      if (this.disabled) {
+        return 'Disabled when recording type includes audio';
+      } else {
+        return "";
+      }
+    }
   }
 };
 

--- a/src/stores/modules/User.store.js
+++ b/src/stores/modules/User.store.js
@@ -8,7 +8,8 @@ const state = {
     'username': localStorage.getItem('username'),
     'email': localStorage.getItem('email'),
   },
-  errorMessage: undefined
+  errorMessage: undefined,
+  recordingTypePref: 'both'
 };
 
 
@@ -83,6 +84,9 @@ const mutations = {
   },
   rejectUpdate (state, response) {
     state.errorMessage = response.message;
+  },
+  updateRecordingTypePref (state, data) {
+    state.recordingTypePref = data;
   }
 };
 


### PR DESCRIPTION
Closes #65 and partially #64 
Will remember preference within a single session but does not currently store between sessions
Provides tooltip to explain why those fields are disabled
Resets fields to default when recording type includes audio (to prevent those fields being included in the query)