### PR TITLE
Fix up prev/next buttons

### DIFF
--- a/src/components/Video/PrevNext.vue
+++ b/src/components/Video/PrevNext.vue
@@ -3,72 +3,64 @@
     <span 
       title="Previous for device, skipping bird &amp; false-positives" 
       @click="nextRecording('previous', 'any', ['interesting'])">
-      <font-awesome-layers class="fa-fw">
-        <font-awesome-icon 
-          icon="asterisk"
-          style="color: red"
-          transform="up-24 right-10 shrink-3"
-          value="?" />
-        <font-awesome-icon 
-          class="fa-3x"
-          icon="angle-double-left" />
-      </font-awesome-layers>
+      <font-awesome-icon 
+        icon="asterisk"
+        style="color: red"
+        transform="up-24 right-10 shrink-3"
+        value="?" />
+      <font-awesome-icon 
+        class="fa-3x"
+        icon="angle-double-left" />
     </span>
     <span 
       title="Previous for device, not manually tagged" 
       @click="nextRecording('previous', 'no-human')">
-      <font-awesome-layers class="fa-fw">
-        <font-awesome-icon 
-          icon="question"
-          style="color: green"
-          transform="up-24 right-10 shrink-3"
-          value="?" />
-        <font-awesome-icon 
-          class="fa-3x"
-          icon="angle-left" />
-      </font-awesome-layers>
+      <font-awesome-icon 
+        icon="question"
+        style="color: green"
+        transform="up-24 right-10 shrink-3"
+        value="?" />
+      <font-awesome-icon 
+        class="fa-3x"
+        icon="angle-left" />
     </span>
     <span 
       title="Previous for device" 
       @click="nextRecording('previous', 'any')">
       <font-awesome-icon 
         icon="angle-left" 
-        size="3x" />
+        class="fa-3x" />
     </span>
     <span 
       title="Next for device" 
       @click="nextRecording('next', 'any')">
       <font-awesome-icon 
         icon="angle-right" 
-        size="3x" />
+        class="fa-3x" />
     </span>
     <span 
       title="Next for device, not manually tagged" 
       @click="nextRecording('next', 'no-human')">
-      <font-awesome-layers class="fa-fw">
-        <font-awesome-icon 
-          class="fa-3x"
-          icon="angle-right" />
-        <font-awesome-icon 
-          icon="question"
-          style="color: green"
-          transform="up-24 left-10 shrink-3"
-          value="?" />
-      </font-awesome-layers>
+      <font-awesome-icon 
+        class="fa-3x"
+        icon="angle-right" />
+      <font-awesome-icon 
+        icon="question"
+        style="color: green"
+        transform="up-24 left-10 shrink-3"
+        value="?" />
     </span>
     <span 
       title="Next for device, skipping birds &amp; false-positives" 
       @click="nextRecording('next', 'any', ['interesting'])">
-      <font-awesome-layers class="fa-fw">
-        <font-awesome-icon 
-          class="fa-3x"
-          icon="angle-double-right" />
-        <font-awesome-icon 
-          icon="asterisk"
-          style="color: red"
-          transform="up-24 left-10 shrink-3"
-          value="?" />
-      </font-awesome-layers>
+      <font-awesome-icon 
+        class="fa-3x"
+        icon="angle-double-right" />
+      <font-awesome-icon 
+        icon="asterisk"
+        style="color: red"
+        transform="up-24 left-10 shrink-3"
+        value="?" />
     </span>
   </div>
 </template>

--- a/src/components/Video/VideoHelp.vue
+++ b/src/components/Video/VideoHelp.vue
@@ -16,55 +16,47 @@
         <p class="col-xs-6">Move between recordings for device</p>
       </b-col>
       <b-col cols="5">
-        <font-awesome-layers class="fa-fw">
-          <font-awesome-icon 
-            icon="question"
-            style="color: green"
-            transform="up-16 shrink-7"
-            value="?" />
-          <font-awesome-icon 
-            class="fa-2x"
-            icon="angle-left" 
-            transform="left-5" />
-        </font-awesome-layers>
-        <font-awesome-layers class="fa-fw">
-          <font-awesome-icon 
-            class="fa-2x"
-            icon="angle-right" 
-            transform="right-5" />
-          <font-awesome-icon 
-            icon="question"
-            style="color: green"
-            transform="up-16 shrink-7"
-            value="?" />
-        </font-awesome-layers>
+        <font-awesome-icon
+          icon="question"
+          style="color: green"
+          transform="up-16 shrink-7"
+          value="?" />
+        <font-awesome-icon
+          class="fa-2x"
+          icon="angle-left"
+          transform="left-5" />
+        <font-awesome-icon
+          class="fa-2x"
+          icon="angle-right"
+          transform="right-5" />
+        <font-awesome-icon
+          icon="question"
+          style="color: green"
+          transform="up-16 shrink-7"
+          value="?" />
       </b-col>
       <b-col cols="7">
         <p class="col-xs-6">Move between recordings for device which have not been manually tagged</p>
       </b-col>
       <b-col cols="5">
-        <font-awesome-layers class="fa-fw">
-          <font-awesome-icon 
-            icon="asterisk"
-            style="color: red"
-            transform="up-16 shrink-7"
-            value="?" />
-          <font-awesome-icon 
-            class="fa-2x"
-            icon="angle-double-left" 
-            transform="left-5" />
-        </font-awesome-layers>
-        <font-awesome-layers class="fa-fw">
-          <font-awesome-icon 
-            class="fa-2x"
-            icon="angle-double-right" 
-            transform="right-5" />
-          <font-awesome-icon 
-            icon="asterisk"
-            style="color: red"
-            transform="up-16 shrink-7"
-            value="?" />
-        </font-awesome-layers>
+        <font-awesome-icon
+          icon="asterisk"
+          style="color: red"
+          transform="up-16 shrink-7"
+          value="?" />
+        <font-awesome-icon
+          class="fa-2x"
+          icon="angle-double-left"
+          transform="left-5" />
+        <font-awesome-icon
+          class="fa-2x"
+          icon="angle-double-right"
+          transform="right-5" />
+        <font-awesome-icon
+          icon="asterisk"
+          style="color: red"
+          transform="up-16 shrink-7"
+          value="?" />
       </b-col>
       <b-col cols="7">
         <p class="col-xs-6">Move between 'interesting' tagged recordings for device where the first tag is not a a bird or false/positive</p>

--- a/src/fontAwesomeIcons.js
+++ b/src/fontAwesomeIcons.js
@@ -1,5 +1,5 @@
-import {library} from '@fortawesome/fontawesome-svg-core';
-import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { library } from '@fortawesome/fontawesome-svg-core';
 import {
   faBatteryFull,
   faBatteryThreeQuarters,

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,6 @@ import Vuelidate from 'vuelidate';
 import Multiselect from 'vue-multiselect';
 import router from './router';
 import FontAwesomeIcon from './fontAwesomeIcons';
-import {FontAwesomeLayers} from '@fortawesome/vue-fontawesome';
 import store from './stores';
 import './styles/global.css';
 import config from './config';
@@ -20,7 +19,6 @@ export default function() {
   Vue.use(Vuelidate);
 
   Vue.component('font-awesome-icon', FontAwesomeIcon);
-  Vue.component('font-awesome-layers', FontAwesomeLayers);
 
   // https://vue-multiselect.js.org
   Vue.component('multiselect', Multiselect);


### PR DESCRIPTION
Since the FontAwesomeLayers import fix the layout of the prev/next
buttons has been messed up. It turns out the correct layout is
achieved by not using `font-awesome-layers` at all!